### PR TITLE
Add support for wasm/wasi

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Right now the only feature this extension supports is setting the right environm
 ```json
 {
     "go.toolsEnvVars": {
+        "GOOS": "linux",
+        "GOARCH": "arm",
         "GOROOT": "/home/user/.cache/tinygo/goroot-go1.14-f930d5b5f36579e8cbd1c139012b3d702281417fb6bdf67303c4697195b9ef1f-syscall",
         "GOFLAGS": "-tags=cortexm,baremetal,linux,arm,nrf51822,nrf51,nrf,microbit,tinygo,gc.conservative,scheduler.tasks"
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,9 @@ export async function activate(context: vscode.ExtensionContext) {
 		});
 		if (!target) return;
 
-		// Obtain information about this target (GOROOT, build tags).
+		// Obtain information about this target (GOOS, GOARCH, GOROOT, build tags).
+		let goos = '';
+		let goarch = '';
 		let goroot = '';
 		let buildTags = '';
 		if (target != '-') {
@@ -64,6 +66,10 @@ export async function activate(context: vscode.ExtensionContext) {
 						goroot = value;
 					} else if (key == 'build tags') {
 						buildTags = value;
+					} else if (key == 'GOOS') {
+						goos = value;
+					} else if (key == 'GOARCH') {
+						goarch = value;
 					}
 				})
 			} catch(err) {
@@ -87,6 +93,8 @@ export async function activate(context: vscode.ExtensionContext) {
 		// This will automatically reload gopls.
 		const config = vscode.workspace.getConfiguration('go', null);
 		let envVars = config.get<NodeJS.Dict<string>>('toolsEnvVars', {});
+		envVars.GOOS = goos ? goos: undefined;
+		envVars.GOARCH = goarch ? goarch: undefined;
 		envVars.GOROOT = goroot ? goroot: undefined;
 		envVars.GOFLAGS = buildTags ? "-tags="+(buildTags.split(' ').join(',')) : undefined;
 		config.update('toolsEnvVars', envVars, vscode.ConfigurationTarget.Workspace);


### PR DESCRIPTION
Add support for wasm and wasi by adding GOOS and GOARCH settings.
Originally, some source code references were incorrect in the GOOS=windows (or GOOS=darwin) environment.
This change will make that part work correctly as well.

Baremetal targets such as microbit will work as before.

